### PR TITLE
Update Bucket and Collector Sum when loading runtime/metrics.Float64Histogram

### DIFF
--- a/dynhist_test.go
+++ b/dynhist_test.go
@@ -314,4 +314,5 @@ func TestCollector_LoadFromRuntimeMetrics(t *testing.T) {
 
 	assert.Greater(t, hh.Bucket.Sum, float64(size))
 	assert.Greater(t, hh.Percentile(50), 1.0)
+	assert.Contains(t, hh.String(), "  +Inf]", "alignment error in second column")
 }

--- a/dynhist_test.go
+++ b/dynhist_test.go
@@ -298,10 +298,10 @@ func TestLearnLatency(t *testing.T) {
 
 func TestCollector_LoadFromRuntimeMetrics(t *testing.T) {
 	samples := []metrics.Sample{{Name: "/gc/heap/allocs-by-size:bytes"}}
-	cnt := 0
+	cnt, size := 0, 350000
 
 	for i := 0; i < 100; i++ {
-		a := make([]byte, 350000)
+		a := make([]byte, size)
 		cnt += len(a)
 	}
 
@@ -312,5 +312,6 @@ func TestCollector_LoadFromRuntimeMetrics(t *testing.T) {
 	hh := dynhist.Collector{}
 	hh.LoadFromRuntimeMetrics(h)
 
+	assert.Greater(t, hh.Bucket.Sum, float64(size))
 	assert.Greater(t, hh.Percentile(50), 1.0)
 }


### PR DESCRIPTION
Change description:
- Update Sum field for each bucket and collector while loading runtime/metrics.Float64Histogram
- Replace `prev` with `c.Bucket.Max` which contains the same value.
- Additionally, update Collector.String to calculate the column width based on the second-last value for the case when last value is `+Inf`.